### PR TITLE
Seta pontos de item ao criar objeto

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,5 +4,13 @@ class Item < ApplicationRecord
 
   belongs_to :user
 
+  after_initialize :set_points  
+
   VALID_ITEMS = { water: 4, food: 3, medicine: 2, ammo: 1 }
+
+  def set_points
+    return if self.name.nil? || VALID_ITEMS.keys.include?(self.name.to_sym) == false
+
+    self.points = VALID_ITEMS[self.name.to_sym]
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#set_points" do
+    it "after initialize sets the item points" do
+      expect(Item.new(name: "water", user_id: 1).points).to eq(4)
+    end
+
+    context "when name is nil on initialize" do
+      it "does not raise error and returns nil" do
+        expect(Item.new(name: nil, user_id: 1).points).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Para que os items tenha pontos definidos ao salvar, é importante inicializa-los com os pontos já definidos.